### PR TITLE
Add support for the delayed_job ‘failure’ method

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ class YourJob < ActiveJob::Base
   def reschedule_at(current_time, attempts)
     current_time + 5.seconds # default is current_time + (attempts**4) + 5
   end
+
+  def failure(job)
+    # notify someone that this task has reached its max_attempts
+  end
 end
 ```
 

--- a/lib/activejob_dj_overrides.rb
+++ b/lib/activejob_dj_overrides.rb
@@ -19,6 +19,10 @@ module ActivejobDjOverrides
     job.reschedule_at(current_time, attempts) rescue (current_time + (attempts**4) + 5)
   end
 
+  def failure
+    job.failure(job) rescue nil
+  end
+
   private
     def job
       @job ||= ActiveJob::Base.deserialize(job_data)

--- a/lib/activejob_dj_overrides/version.rb
+++ b/lib/activejob_dj_overrides/version.rb
@@ -1,3 +1,3 @@
 module ActivejobDjOverrides
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
I was missing the delayed_job 'failure' method in my ActiveJob tasks, so I added this method to your helpful gem!